### PR TITLE
fix: Crash on enhanced.

### DIFF
--- a/src/native_hooks/native_hooks.cpp
+++ b/src/native_hooks/native_hooks.cpp
@@ -155,6 +155,15 @@ namespace big
 		add_native_detour(0x158C16F5E4CF41F8, all_scripts::RETURN_TRUE);  // NETWORK_CASINO_CAN_BET
 		add_native_detour(0x930DE22F07B1CCE3, all_scripts::RETURN_FALSE); // SC_PROFANITY_GET_STRING_STATUS
 
+		for (int i = 0; i < 176; i++)
+		{
+			rage::scrProgram* program = g_pointers->m_script_programs[i];
+			if (program != nullptr && program->m_code_blocks && program->m_code_size)
+			{
+				hook_program(program);
+			}
+		}
+
 		g_native_hooks = this;
 	}
 

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -54,6 +54,13 @@ namespace big
 			m_run_script_threads = ptr.sub(0xA).as<functions::run_script_threads_t>();
 		});
 
+		main_batch.add("Script programs", "48 89 01 48 8D 0D ? ? ? ? E8 ? ? ? ? 8B", -1, -1, eGameBranch::Legacy, [this](memory::handle ptr) {
+			m_script_programs = ptr.add(6).rip().add(0xD8).as<decltype(m_script_programs)>();
+		});
+		main_batch.add("Script programs", "48 C7 84 C8 D8 00 00 00 00 00 00 00", -1, -1, eGameBranch::Enhanced, [this](memory::handle ptr) {
+			m_script_programs = ptr.add(0x13).add(3).rip().add(0xD8).as<decltype(m_script_programs)>();
+		});
+
 		main_batch.add("Script globals", "48 8D 15 ? ? ? ? 4C 8B C0 E8 ? ? ? ? 48 85 FF 48 89 1D", -1, -1, eGameBranch::Legacy, [this](memory::handle ptr) {
 			m_script_globals = ptr.add(3).rip().as<std::int64_t**>();
 		});

--- a/src/pointers.hpp
+++ b/src/pointers.hpp
@@ -27,6 +27,7 @@ namespace big
 		rage::scrNativeRegistrationTable* m_native_registration_table{};
 
 		rage::atArray<rage::scrThread*>* m_script_threads{};
+		rage::scrProgram** m_script_programs{};
 		functions::run_script_threads_t m_run_script_threads{};
 		std::int64_t** m_script_globals{};
 		PVOID m_init_native_tables{};


### PR DESCRIPTION
The old `script_program_table` was apparently causing crashes on enhanced.
This replaces it with [`script_programs` array from YimMenuV2](https://github.com/YimMenu/YimMenuV2/blob/259354945bd4638f8d88f8e63ac680df36f63bbb/src/game/pointers/Pointers.cpp#L114-L117).

Closes #10 